### PR TITLE
Improve reconnect logic

### DIFF
--- a/royal_trainer_client/src/App.tsx
+++ b/royal_trainer_client/src/App.tsx
@@ -331,6 +331,7 @@ const App: React.FC = () => {
 
     try {
       await connect(sessionCode);
+      setIsConnecting(false);
     } catch (error) {
       console.error('Connection failed:', error);
       setIsConnecting(false);
@@ -344,6 +345,7 @@ const App: React.FC = () => {
 
   const handleDisconnect = () => {
     disconnect();
+    setIsConnecting(false);
     setStartTime(null);
     setElapsedTime('00:00:00');
     setShowConnectionLoader(false);

--- a/server/handlers/websocket_handlers.py
+++ b/server/handlers/websocket_handlers.py
@@ -433,10 +433,15 @@ async def handle_disconnect(current_session: Session, ws: WebSocket, session_man
             max_latency = max(connection_latencies)
             print(f"📊 Final latency stats for {connection_id} - Avg: {avg_latency:.1f}ms, Min: {min_latency:.1f}ms, Max: {max_latency:.1f}ms, Frames: {len(connection_latencies)}")
 
-    # Remove empty session
+    # Mark session activity but allow reconnect within cleanup window
+    current_session.last_activity = datetime.now()
+
+    # Defer removal of completely empty sessions to the periodic cleanup task
     if current_session.is_empty():
-        session_manager.remove_session(current_session.session_code)
-        print(f"🗑️ Empty session {current_session.session_code} removed")
+        print(
+            f"🗑️ Session {current_session.session_code} now empty - will be"
+            " removed by cleanup task if no reconnect occurs"
+        )
 
 async def get_session_latency_stats(session_code: str, session_manager: SessionManager) -> dict:
     """Get latency statistics for a session"""


### PR DESCRIPTION
## Summary
- allow reconnect by deferring session removal to cleanup task
- stop showing connecting state after successful connection
- ensure disconnect clears connecting flag

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68433985713c8327b54d03468d3ca55f